### PR TITLE
ignore errors checking existence of relations

### DIFF
--- a/src/Zofe/Rapyd/DataForm/Field/Field.php
+++ b/src/Zofe/Rapyd/DataForm/Field/Field.php
@@ -105,7 +105,7 @@ abstract class Field extends Widget
 
         if (isset($this->model) &&
             method_exists($this->model, $relation) &&
-            is_a($this->model->$relation(), 'Illuminate\Database\Eloquent\Relations\Relation')
+            is_a(@$this->model->$relation(), 'Illuminate\Database\Eloquent\Relations\Relation')
         ) {
 
             $this->relation = $this->model->$relation($relation);


### PR DESCRIPTION
I have a column named `guard`, and the code `$this->model->$relation()` executes Eloquent::guard() method to check whether relation method exists, and the exception occurs; `Argument 1 passed to Illuminate\Database\Eloquent\Model::guard() must be of the type array, none given`. 

Another column name, the same name of Eloquent methods exists, will have the same problem, so I think it's good to change ignoring errors like `@$this->model->$relation()`.

Thanks.
