### PR TITLE
Fixed bug which declined to add custom NSed fields to DataForm

### DIFF
--- a/src/Zofe/Rapyd/DataForm/DataForm.php
+++ b/src/Zofe/Rapyd/DataForm/DataForm.php
@@ -58,10 +58,10 @@ class DataForm extends Widget
      */
     public function add($name, $label, $type, $validation = '')
     {
-        if (strpos($type, "\\")) {
+        if (strpos($type, "\\") !== false) {
             $field_class = $type;
         } else {
-            $field_class = '\Zofe\Rapyd\DataForm\Field' . "\\" . ucfirst($type);
+            $field_class = '\Zofe\Rapyd\DataForm\Field\\' .  ucfirst($type);
         }
 
         //instancing


### PR DESCRIPTION
Fields of class like '\My\Custom\NS\Field' was unable to be added to DataForm.
