### PR TITLE
Fix missing form-control css class for field

### DIFF
--- a/src/Zofe/Rapyd/DataForm/Field/Field.php
+++ b/src/Zofe/Rapyd/DataForm/Field/Field.php
@@ -23,6 +23,7 @@ abstract class Field extends Widget
     public $rel_other_key;
 
     public $attributes;
+    public $css_class = "form-control";
     public $output = "";
     public $visible = true;
     public $extra_output = "";


### PR DESCRIPTION
Add default $css_class to fix missing class in DataFilter form.