### PR TITLE
Support developer assigned string length sanitization

### DIFF
--- a/config/rapyd.php
+++ b/config/rapyd.php
@@ -2,6 +2,16 @@
 
 
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Data Cell sanitization defaults
+    |--------------------------------------------------------------------------
+    */
+    'sanitize' => [
+        'num_characters' => 100, // Number of characters to return during cell value sanitization. 0 = no limit
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Field Class

--- a/src/DataForm/Field/Field.php
+++ b/src/DataForm/Field/Field.php
@@ -82,7 +82,7 @@ abstract class Field extends Widget
     {
         parent::__construct();
 
-        $this->attributes = Config::get('rapyd::field.attributes');
+        $this->attributes = Config::get('rapyd.field.attributes');
         $this->model = $model;
         $this->model_relations = $model_relations;
 

--- a/src/DataGrid/DataGrid.php
+++ b/src/DataGrid/DataGrid.php
@@ -171,6 +171,9 @@ class DataGrid extends DataSet
         } elseif (is_object($tablerow)) {
 
             $value = @$tablerow->{$column->name};
+            if ($sanitize) {
+                $value = $this->sanitize($value);
+            }
         //fieldname in an array
         } elseif (is_array($tablerow) && isset($tablerow[$column->name])) {
 

--- a/src/DataGrid/DataGrid.php
+++ b/src/DataGrid/DataGrid.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\View;
 use Zofe\Rapyd\DataSet as DataSet;
 use Zofe\Rapyd\Persistence;
+use Illuminate\Support\Facades\Config;
 
 class DataGrid extends DataSet
 {
@@ -255,7 +256,8 @@ class DataGrid extends DataSet
 
     protected function sanitize($string)
     {
-        return str_limit(nl2br(htmlspecialchars($string)), 30);
+        $result = nl2br(htmlspecialchars($string));
+        return Config::get('rapyd.sanitize.num_characters') > 0 ? str_limit($result, Config::get('rapyd.sanitize.num_characters')) : $result;
     }
 
 }

--- a/src/DataGrid/DataGrid.php
+++ b/src/DataGrid/DataGrid.php
@@ -171,9 +171,6 @@ class DataGrid extends DataSet
         } elseif (is_object($tablerow)) {
 
             $value = @$tablerow->{$column->name};
-            if ($sanitize) {
-                $value = $this->sanitize($value);
-            }
         //fieldname in an array
         } elseif (is_array($tablerow) && isset($tablerow[$column->name])) {
 


### PR DESCRIPTION
As per comments, new config section allows you to control the number of characters to return during cell value sanitization. 0 = no limit

Also fixed an issue with a double-colon reference to the field.attributes config setting which does not work in L5 and returns null. Corrected with dot notation.
