### PR TITLE
Support for options with "reset" button

### DIFF
--- a/src/DataForm/DataForm.php
+++ b/src/DataForm/DataForm.php
@@ -187,7 +187,7 @@ class DataForm extends Widget
      *
      * @return $this
      */
-    public function reset($name = "", $position = "BL")
+    public function reset($name = "", $position = "BL", $options = array())
     {
         if ($name == "") $name = trans('rapyd::rapyd.reset');
         $this->link($this->url->current(true), $name, $position);


### PR DESCRIPTION
The PHPdoc param comment was already in place, but the function did not have the options parameter. With this fix, you can for example change the CSS class for the reset button.