### PR TITLE
Changes in Date field to use in DataFilter

### DIFF
--- a/src/DataForm/Field/Date.php
+++ b/src/DataForm/Field/Date.php
@@ -59,6 +59,15 @@ class Date extends Field
     }
 
     /**
+     * overwrite value to obtain a iso date
+     */
+    public function getValue()
+    {
+        parent::getValue();
+        $this->value = $this->humanDateToIso($this->value);
+    }
+    
+    /**
      * overwrite new value to store a iso date
      */
     public function getNewValue()
@@ -114,9 +123,7 @@ class Date extends Field
             case "create":
             case "modify":
                 if ($this->value != "") {
-                    if (!$this->is_refill) {
-                        $this->value = $this->isoDateToHuman($this->value);
-                    }
+                    $this->value = $this->isoDateToHuman($this->value);
                 }
 
                 Rapyd::css('datepicker/datepicker3.css');

--- a/src/DataForm/Field/Daterange.php
+++ b/src/DataForm/Field/Daterange.php
@@ -14,7 +14,7 @@ class Daterange extends Date
 
     public function getValue()
     {
-        parent::getValue();
+        Field::getValue();
         $this->values = explode($this->serialization_sep, $this->value);
         foreach ($this->values as $value) {
             $values[] = $this->humanDateToIso($value);


### PR DESCRIPTION
These are changes to provide automatic conversions in format dates of Date field when it's used in DataFilter to compare the values with DB. The same that it's already implemented for Daterange fields.