### PR TITLE
Cell should use  column's attributes

### DIFF
--- a/src/DataGrid/DataGrid.php
+++ b/src/DataGrid/DataGrid.php
@@ -60,6 +60,7 @@ class DataGrid extends DataSet
                     $callable = $column->cell_callable;
                     $cell->value($callable($cell->value));
                 }
+                $cell->attributes = $column->attributes;
                 $row->add($cell);
             }
 


### PR DESCRIPTION
It's usefully for setting attributes on cell.

eg:  a disable user link each row with DIY css class:

```php
        $grid = DataGrid::source(new \User());
        $grid->add('Disable', 'Disable User')
                 ->link('{{ "/path/disable/id=" . $id }}')
                 ->attributes(['class' => 'dlsable-link', 'onclick' = 'alert("test")']);
```