### PR TITLE
Add an optional upload url to redactor

### DIFF
--- a/src/DataForm/Field/Redactor.php
+++ b/src/DataForm/Field/Redactor.php
@@ -5,6 +5,14 @@ use Zofe\Rapyd\Rapyd;
 class Redactor extends Field
 {
   public $type = "text";
+  public $upload_url = null; 
+
+  public function upload($url)
+  {
+      $this->upload_url = $url;
+
+      return $this;
+  }
 
   public function build()
   {
@@ -32,7 +40,20 @@ class Redactor extends Field
         Rapyd::js('redactor/redactor.min.js');
         Rapyd::css('redactor/css/redactor.css');
         $output  = Form::textarea($this->name, $this->value, $this->attributes);
-        Rapyd::script("$('#".$this->name."').redactor();");
+
+		$redactor_params = '';
+
+		if ($this->upload_url)
+		{
+			$redactor_params = "imageUpload: '" . $this->upload_url . "?_token=" . csrf_token() . "'";
+		}
+
+        Rapyd::script("$('#".$this->name."').redactor({".$redactor_params."});");
+
+		$redactor = "$('#".$this->name."').redactor({
+			imageUpload: '" . $this->model->redactor_upload_url . "'
+		});";
+		
 
         break;
 

--- a/src/DataForm/Field/Redactor.php
+++ b/src/DataForm/Field/Redactor.php
@@ -50,11 +50,6 @@ class Redactor extends Field
 
         Rapyd::script("$('#".$this->name."').redactor({".$redactor_params."});");
 
-		$redactor = "$('#".$this->name."').redactor({
-			imageUpload: '" . $this->model->redactor_upload_url . "'
-		});";
-		
-
         break;
 
       case "hidden":


### PR DESCRIPTION
This allows for images to be uploaded within a redactor field.

The syntax to use this is 

````
$url = route('entity.upload');
$edit->add('text_field','Text Field', 'redactor')->upload($url);
````

You may define your route to point to some controller method such as this

````
public function upload(Request $request)
{
	$image = $request->file('file');

	// copy/save file, add to db, whatever
	// $path = ...

	// Output an image tag, eg. using Illuminate\HTML
	return HTML::image(asset($path));  
}
````

I'm happy to update the wiki if this PR is accepted.