### PR TITLE
Two small changes

### DIFF
--- a/src/DataForm/Field/Checkboxgroup.php
+++ b/src/DataForm/Field/Checkboxgroup.php
@@ -15,6 +15,11 @@ class Checkboxgroup extends Field
     public $unchecked_value = 0;
     public $clause = "wherein";
 
+    public function separator($separator)
+    {
+        $this->separator = $separator;
+    }
+
     public function getValue()
     {
         parent::getValue();

--- a/src/DataForm/Field/Field.php
+++ b/src/DataForm/Field/Field.php
@@ -423,6 +423,9 @@ abstract class Field extends Widget
         if (is_array($options)) {
             $this->options += $options;
         }
+        else {
+            $this->options += $options->all();
+        }
 
         return $this;
     }

--- a/src/DataForm/Field/Radiogroup.php
+++ b/src/DataForm/Field/Radiogroup.php
@@ -11,6 +11,11 @@ class Radiogroup extends Field
     public $separator = "&nbsp;&nbsp;";
     public $clause = "where";
 
+    public function separator($separator)
+    {
+        $this->separator = $separator;
+    }
+
     public function getValue()
     {
         parent::getValue();


### PR DESCRIPTION
Hi Felice,

Here are two small changes for your consideration.

* Add a collection as well as an array: 

I am not sure if this is just being pedantic, or if the Rapyd documentation is incorrect, but this solution allows the options member function ro accept wither an array or a collection.

On the page https://github.com/zofe/rapyd-laravel/wiki/Field-list, there is an example 

checkboxgroup (checkbox list), usually using relation.fieldname to store values in a pivot table, for a belongsTo relation

                   $edit->add('categories','Categories','checkboxgroup')
                        ->options(Category::lists("name", "category_id"));

This does not work because the options member function only accepts arrays.

*  Add separator setter function:

I am not sure about this at all, but I think it is convenient to have a way of changing the separator in a simple way, for example:

                    $form->add($fieldName, $rating->prompt_text, 'radiogroup')
                        ->options($choices)
                        ->separator("<br />");

Is there a simple way to achieve the same result without adding the new setter?

Cheers

Hamish