### PR TITLE
DataGrid notifies when empty

### DIFF
--- a/lang/en/rapyd.php
+++ b/lang/en/rapyd.php
@@ -18,6 +18,7 @@ return array(
     'err'        => 'Error reading record.',
     'err_unknown'=> 'Error, no record selected',
     'err_dup_pk' => 'Error, duplicated primary key',
+    'no_records' => 'There are no records to show.',
     'conf_delete'=> 'Do you want to eliminate the record?',
 
 );

--- a/views/datagrid.blade.php
+++ b/views/datagrid.blade.php
@@ -30,6 +30,9 @@
     </tr>
     </thead>
     <tbody>
+    @if (count($dg->rows) == 0)
+        <tr><td colspan="{!! count($dg->columns) !!}">{!! trans('rapyd::rapyd.no_records') !!}</td></tr>
+    @endif
     @foreach ($dg->rows as $row)
         <tr{!! $row->buildAttributes() !!}>
             @foreach ($row->cells as $cell)


### PR DESCRIPTION
When the DataGrid has no records to show, it displays the
`rapyd::rapyd.no_records` message in a row of the DataGrid which spans
all table columns.