### PR TITLE
Fix rendering in show status

### DIFF
--- a/views/dataform/field.blade.php
+++ b/views/dataform/field.blade.php
@@ -10,7 +10,7 @@
     @endif
 
 @else
-    <div class="form-group{!!$field->has_error!!}" id="fg_{!! $field->name !!}">
+    <div class="form-group clearfix{!!$field->has_error!!}" id="fg_{!! $field->name !!}" >
 
         @if ($field->has_label)
             <label for="{!! $field->name !!}" class="col-sm-2 control-label{!! $field->req !!}">{!! $field->label !!}</label>


### PR DESCRIPTION
When rendering in the show status, if the labels span multiple lines,
the formatting breaks. Adding the clearfix to the fieldgroup ensures
that each row of the form is correctly rendered.