### PR TITLE
Allow DataForm status to be set externally

### DIFF
--- a/src/DataForm/DataForm.php
+++ b/src/DataForm/DataForm.php
@@ -90,6 +90,7 @@ class DataForm extends Widget
     protected $has_labels = true;
     protected $has_placeholders = false;
     protected $form_callable = '';
+    protected $status_set = false;
 
     public function __construct()
     {
@@ -325,12 +326,24 @@ class DataForm extends Widget
         return ($this->process_status == $process_status);
     }
 
+    public function setStatus($status)
+    {
+        $this->status = $status;
+        $this->status_set = true;
+    }
+
     protected function sniffStatus()
     {
-        if (isset($this->model)) {
-            $this->status = ($this->model->exists) ? "modify" : "create";
-        } else {
-            $this->status = "create";
+        if (!$this->status_set) {
+            if (isset($this->model)) {
+                if ($this->model->exists) {
+                    $this->setStatus("modify");
+                } else {
+                    $this->setStatus("create");
+                }
+            } else {
+                $this->setStatus("create");
+            }
         }
     }
 


### PR DESCRIPTION
In cases where rapyd should be used to render a form in a specific way, for instance to show the user what he has input, it is useful to be able to tell rapyd how it should render the form.
