### PR TITLE
Fix CSV \r on Macs

### DIFF
--- a/src/DataGrid/DataGrid.php
+++ b/src/DataGrid/DataGrid.php
@@ -122,6 +122,14 @@ class DataGrid extends DataSet
 
                 $cell = new Cell($column->name);
                 $value =  str_replace('"', '""',str_replace(PHP_EOL, '', strip_tags($this->getCellValue($column, $tablerow, $sanitize))));
+
+                // Excel for Mac is pretty stupid, and will break a cell containing \r, such as user input typed on a
+                // old Mac.
+                // On the other hand, PHP will not deal with the issue for use, see for instance:
+                // http://stackoverflow.com/questions/12498337/php-preg-replace-replacing-line-break
+                // We need to normalize \r and \r\n into \n, otherwise the CSV will break on Macs
+                $value = preg_replace('/\r\n|\n\r|\n|\r/', "\n", $value);
+
                 $cell->value($value);
                 $row->add($cell);
             }


### PR DESCRIPTION
Excel for Mac is pretty stupid, and will break a cell containing \r, such as user input typed on a
old Mac.
On the other hand, PHP will not deal with the issue for use, see for instance:
http://stackoverflow.com/questions/12498337/php-preg-replace-replacing-line-break
We need to normalize \r and \r\n into \n, otherwise the CSV will break on Macs