### PR TITLE
Support for laravel eloquent's $cast property

### DIFF
--- a/src/DataForm/Field/Checkboxgroup.php
+++ b/src/DataForm/Field/Checkboxgroup.php
@@ -24,7 +24,12 @@ class Checkboxgroup extends Field
     {
         parent::getValue();
 
-        $this->values = explode($this->serialization_sep, $this->value);
+        if (is_array($this->value)) {
+            $this->values = $this->value;
+        }
+        else {
+            $this->values = explode($this->serialization_sep, $this->value);
+        }
 
         $description_arr = array();
         foreach ($this->options as $value => $description) {

--- a/src/DataForm/Field/Multiselect.php
+++ b/src/DataForm/Field/Multiselect.php
@@ -20,7 +20,12 @@ class Multiselect extends Field
     {
         parent::getValue();
 
-        $this->values = explode($this->serialization_sep, $this->value);
+        if (is_array($this->value)) {
+            $this->values = $this->value;
+        }
+        else {
+            $this->values = explode($this->serialization_sep, $this->value);
+        }
 
         $description_arr = array();
         foreach ($this->options as $value => $description) {


### PR DESCRIPTION
When you use eloquent model's property casting you don't need to unserialize with explode.

```
protected $casts = [
        'gender' => 'array'
];
```