### PR TITLE
Bugfix: add missing variable to Tags field

### DIFF
--- a/src/DataForm/Field/Tags.php
+++ b/src/DataForm/Field/Tags.php
@@ -30,6 +30,8 @@ class Tags extends Field
     public $is_local;
     public $description = '';
 
+    public $fill_tags = '';
+
     public function options($options)
     {
         $this->is_local = true;


### PR DESCRIPTION
This solves #274 
The fill_tags variable wasn't declared. In some cases this causes the Tags field to fail.
I added a decleration which fixes the problem