### PR TITLE
Fixed Bug with Redactor field

### DIFF
--- a/src/DataForm/Field/Redactor.php
+++ b/src/DataForm/Field/Redactor.php
@@ -32,7 +32,7 @@ class Redactor extends Field
         Rapyd::js('redactor/redactor.min.js');
         Rapyd::css('redactor/css/redactor.css');
         $output  = Form::textarea($this->name, $this->value, $this->attributes);
-        Rapyd::script("$('#".$this->name."').redactor();");
+        Rapyd::script("$('[id=\"".$this->name."\"]').redactor();");
 
         break;
 


### PR DESCRIPTION
[Bug #373](https://github.com/zofe/rapyd-laravel/issues/373):
If field name contains '[]' (for post array), than Redactor plugin cannot been initialized, because jQuery selector "#" (by id) cannot contains square brackets.