### PR TITLE
Add Key Feature for Google Maps Authentification

### DIFF
--- a/src/DataForm/Field/Map.php
+++ b/src/DataForm/Field/Map.php
@@ -11,6 +11,7 @@ class Map extends Field
     public $lat = "lat";
     public $lon = "lon";
     public $zoom = 12;
+    public $key;
 
     public function latlon($lat, $lon)
     {
@@ -24,7 +25,23 @@ class Map extends Field
         $this->zoom = $zoom;
         return $this;
     }
-    
+
+    public function key($key)
+    {
+        $this->key = $key;
+        return $this;
+    }
+
+    public function getUrl()
+    {
+        $url = 'https://maps.googleapis.com/maps/api/js?v=3.exp';
+        if ($this->key)
+        {
+            $url .= '&key=' . $this->key;
+        }
+        return $url;
+    }
+
     public function getValue()
     {
         $process = (\Input::get('search') || \Input::get('save')) ? true : false;
@@ -103,7 +120,7 @@ class Map extends Field
                 $output  = Form::hidden($this->lat, $this->value['lat'], ['id'=>$this->lat]);
                 $output .= Form::hidden($this->lon, $this->value['lon'], ['id'=>$this->lon]);
                 $output .= '<div id="map_'.$this->name.'" style="width:500px; height:500px"></div>';
-                $output .= '<script src="https://maps.googleapis.com/maps/api/js?v=3.exp"></script>';
+                $output .= '<script src="' . $this->getUrl() . '"></script>';
                 
             \Rapyd::script("
         


### PR DESCRIPTION
When I try to implement a map in my Dataform, I have a Javascript Error:
```
Google Maps API error: MissingKeyMapError 
```
This error occurs because we don't provide a key when we fetch the Google Maps Url.

So, the feature is pretty simple:
I add a key() method which allows to specify a Google Maps Key.
Documentation is here : https://developers.google.com/maps/documentation/javascript/get-api-key

Implementation example:
```
$form->add('map','Position','map')
                ->latlon('latitude','longitude')
                ->zoom(6)
                ->key('MY_GOOGLE_MAPS_API_KEY');
```