### PR TITLE
PHP 7.2 compatibility for DataSet / DataGrid

### DIFF
--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -99,7 +99,7 @@ class DataSet extends Widget
             }
 
         } else {
-            if (count($this->orderby) && ($this->orderby[0] == $field)) {
+            if (!empty($this->orderby) && ($this->orderby[0] == $field)) {
                 $dir = $this->orderby[1];
 
                 return ($direction == "" || $dir == $direction) ? true : false;


### PR DESCRIPTION
Hi!

Prior to PHP 7.2, `count()` worked on scalar values, always returning `0` for `null`, and `1` for strings and numbers.

In PHP 7.2, it is no longer the case; `count()` expects an array or a `Countable` implementation (see [PHP documentation](http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types)):

```sh
$ php -r 'count(null);'
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in Command line code on line 1
```

The package currently uses `count()` on `DataSet::$orderby` in `DataSet::onOrderby()`, called from the `rapyd::datagrid` view.

Since the default value for `DataSet::$orderby` is `null`, the grid does not work in PHP 7.2, unless the default order is set explicitly (i.e. with `$grid->orderBy('field', 'direction')`).

I've replaced that with `!empty()` to make it compatible with PHP 7.2.

---

**Note:**
Until this is merged (or the issue otherwise fixed), a simple workaround for package users is to add
```php
$grid->orderBy(null);
```
to your code.