### PR TITLE
Fix for issue #431: Not all records are exported when calling DataGrid::buildCSV()

### DIFF
--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -182,10 +182,19 @@ class DataSet extends Widget
             case "PDOStatement":
                 //orderby is handled by the code providing the PDOStatement
 
-                //calculate page variable.
-                $limit = $this->limit ? $this->limit : 100000;
-                $current_page = $this->url->value('page'.$this->cid, 0);
-                $offset = (max($current_page-1,0)) * $limit;
+                // Calculate page variable.
+                // $limit is set to only export a subset
+                if (isset($this->limit)) {
+                    $limit = $this->limit;
+                    $current_page = $this->url->value('page'.$this->cid, 0);
+                    $offset = (max($current_page-1,0)) * $limit;
+                }
+                // $limit is null to export every records.
+                else {
+                    $limit = null;
+                    $current_page = 0;
+                    $offset = 0;
+                }
 
                 $rows = array();
                 $skip = $cnt = 0;
@@ -195,10 +204,14 @@ class DataSet extends Widget
                         $skip++;
                         continue;
                     }
-                    //gather the rows to render
-                    elseif ($cnt <= $limit ) {
+                    //gather the rows to render.
+                    else {
                         $rows[$cnt] = $row;
                         $cnt++;
+                    }
+                    // If limit is set and we are passed it, break out of loop.
+                    if (isset($limit) && ($cnt > $limit)) {
+                        break;
                     }
                 }
 
@@ -226,9 +239,19 @@ class DataSet extends Widget
                     }
                 }
 
-                $limit = $this->limit ? $this->limit : 100000;
-                $current_page = $this->url->value('page'.$this->cid, 0);
-                $offset = (max($current_page-1,0)) * $limit;
+                // $limit is set to only export a subset
+                if (isset($this->limit)) {
+                    $limit = $this->limit;
+                    $current_page = $this->url->value('page'.$this->cid, 0);
+                    $offset = (max($current_page-1,0)) * $limit;
+                }
+                // $limit is null to export every records.
+                else {
+                    $limit = count($this->source);
+                    $current_page = 0;
+                    $offset = 0;
+                }
+
                 $this->data = array_slice($this->source, $offset, $limit);
                 $this->total_rows = count($this->source);
                 $this->paginator = new LengthAwarePaginator($this->data, $this->total_rows, $limit, $current_page,


### PR DESCRIPTION
As the title says, fix for issue #431.
This also has a significant yet simple performance improvement to the loop gathering the data/rows from ```$this->source``` for the PDOStatement on lines 212:215 of DataSet::build(), by simply getting out of the loop as soon as all required records have been collected. My mistake for not including this in my initial PR.

Note: I am working on #430, but it is probably better and easier to understand if the PR's are kept to small units.

Cheers.
/s