### PR TITLE
Export big results crashes

### DIFF
--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -121,7 +121,7 @@ class DataSet extends Widget
         return $this;
     }
 
-    public function build()
+    public function build($rowproc = null)
     {
         if (is_string($this->source) && strpos(" ", $this->source) === false) {
             //tablename
@@ -204,10 +204,14 @@ class DataSet extends Widget
                         $skip++;
                         continue;
                     }
-                    //gather the rows to render.
+                    //gather the rows to render
                     else {
-                        $rows[$cnt] = $row;
-                        $cnt++;
+                        if (is_callable($rowproc)) {
+                            $rowproc($row);
+                        } else {
+                            $rows[$cnt] = $row;
+                            $cnt++;
+                        }
                     }
                     // If limit is set and we are passed it, break out of loop.
                     if (isset($limit) && ($cnt > $limit)) {

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -182,10 +182,19 @@ class DataSet extends Widget
             case "PDOStatement":
                 //orderby is handled by the code providing the PDOStatement
 
-                //calculate page variable.
-                $limit = $this->limit ? $this->limit : 100000;
-                $current_page = $this->url->value('page'.$this->cid, 0);
-                $offset = (max($current_page-1,0)) * $limit;
+                // Calculate page variable.
+                // $limit is set to only export a subset
+                if (isset($this->limit)) {
+                    $limit = $this->limit;
+                    $current_page = $this->url->value('page'.$this->cid, 0);
+                    $offset = (max($current_page-1,0)) * $limit;
+                }
+                // $limit is null to export every records.
+                else {
+                    $limit = null;
+                    $current_page = 0;
+                    $offset = 0;
+                }
 
                 $rows = array();
                 $skip = $cnt = 0;
@@ -195,10 +204,14 @@ class DataSet extends Widget
                         $skip++;
                         continue;
                     }
-                    //gather the rows to render
-                    elseif ($cnt <= $limit ) {
+                    //gather the rows to render.
+                    else {
                         $rows[$cnt] = $row;
                         $cnt++;
+                    }
+                    // If limit is set and we are passed it, break out of loop.
+                    if (isset($limit) && ($cnt > $limit)) {
+                        break;
                     }
                 }
 
@@ -226,9 +239,19 @@ class DataSet extends Widget
                     }
                 }
 
-                $limit = $this->limit ? $this->limit : 100000;
-                $current_page = $this->url->value('page'.$this->cid, 0);
-                $offset = (max($current_page-1,0)) * $limit;
+                // $limit is set to only export a subset
+                if (isset($this->limit)) {
+                    $limit = $this->limit;
+                    $current_page = $this->url->value('page'.$this->cid, 0);
+                    $offset = (max($current_page-1,0)) * $limit;
+                }
+                // $limit is null to export every records.
+                else {
+                    $limit = count($this->source);
+                    $current_page = 0;
+                    $offset = 0;
+                }
+
                 $this->data = array_slice($this->source, $offset, $limit);
                 $this->total_rows = count($this->source);
                 $this->paginator = new LengthAwarePaginator($this->data, $this->total_rows, $limit, $current_page,


### PR DESCRIPTION
Fix #430.

By moving the ```foreach``` loop that process each record from ```DataGrid::buildCSV()``` to it's own method ```processTableRow``` we can now pass it as a closure to ```DataSet::Build()``` and have it called directly as records are being fetched instead of trying to hold all records in memory for later processing therefore avoiding to memory allocation error.

Calling ```DataGrid::buildCSV()``` in this fashion:
```php
  $grid->buildCSV($reportDirAndFileName, $timestamp = '', $sanitize = true, $del = array(), $directToFile = true);
```
buildCSV is now able to handle huge result sets that are saved in ```$reportDirAndFileName``` which can be streamed all at once when ready.

Otherwise any call to ```DataGrid::buildCSV()``` using previous syntax remains unchanged.

