### PR TITLE
php7.2 fix Parameter must be an array for count()

### DIFF
--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -36,7 +36,7 @@ class DataSet extends Widget
     protected $type;
     protected $limit;
     protected $total_rows;
-    protected $orderby;
+    protected $orderby = array();
     protected $orderby_uri_asc;
     protected $orderby_uri_desc;
 


### PR DESCRIPTION
count(): Parameter must be an array or an object that implements Countable