### PR TITLE
Update Autocomplete Field to fix count() bug

### DIFF
--- a/src/DataForm/Field/Autocomplete.php
+++ b/src/DataForm/Field/Autocomplete.php
@@ -15,7 +15,7 @@ class Autocomplete extends Field
 
     public $remote;
 
-    public $local_options;
+    public $local_options = [];
 
     public $record_id;
     public $record_label;


### PR DESCRIPTION
Following advice in https://github.com/zofe/rapyd-laravel/issues/437 I have initialized the `$local_options` variable to prevent a bug that was occurring with Autocomplete Fields on Laravel 5.8 and PHP 7.3

For reference, the error was

`count(): Parameter must be an array or an object that implements Countable`