### PR TITLE
file upload fix for laravel 5.8

### DIFF
--- a/src/DataForm/Field/File.php
+++ b/src/DataForm/Field/File.php
@@ -228,7 +228,7 @@ class File extends Field
             $this->file->move($this->path, $filename);
             $this->saved = $this->path. $filename;
         }
-        \Event::fire('rapyd.uploaded.'.$this->name);
+        \Event::dispatch('rapyd.uploaded.'.$this->name);
 
         return true;
     }


### PR DESCRIPTION
Changed "\Event::fire('rapyd.uploaded.'.$this->name);" to "\Event::dispatch('rapyd.uploaded.'.$this->name);" because fire() method has been removed in laravel 5.8. and dispatch() method should be used. 

Source: https://laravel.com/docs/5.8/upgrade

This update fixes error "Call to undefined method Illuminate\Events\Dispatcher::fire()" when trying to upload file in rapyd edit.