### PR TITLE
PHP 7.3 compatibility fix: "continue" in switch

### DIFF
--- a/src/DataForm/Field/Field.php
+++ b/src/DataForm/Field/Field.php
@@ -582,7 +582,7 @@ abstract class Field extends Widget
                     $this->relation->detach($old_data);
 
                     if ($data=='') {
-                        continue;
+                        break;
                     }
 
                     if (is_callable($this->extra_attributes)) {


### PR DESCRIPTION
you have this in the latest version, 6.0+, but for laravel 5.* on php 7.3 ... this creates problems